### PR TITLE
Update to use heroku-cli-utils

### DIFF
--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -15,10 +15,7 @@ Example:
   needsAuth: true,
   needsApp: true,
   variableArgs: true,
-  run: function (context) {
-    // Get an authenticated API object
-    var heroku = new Heroku({token: context.auth.password});
-
+  run: cli.command(co.wrap(function* (context, heroku) {
     // Get the config vars for the app
     heroku.apps(context.app).configVars().info(function (err, config) {
       if (err) { throw err; }
@@ -41,5 +38,5 @@ Example:
         process.exitCode = err;
       });
     });
-  }
+  }))
 };

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -1,4 +1,6 @@
-var Heroku = require('heroku-client');
+'use strict';
+let cli = require('heroku-cli-util');
+let co  = require('co');
 var spawn = require('child_process').spawn;
 
 

--- a/lib/commands/run.js
+++ b/lib/commands/run.js
@@ -17,26 +17,24 @@ Example:
   variableArgs: true,
   run: cli.command(co.wrap(function* (context, heroku) {
     // Get the config vars for the app
-    heroku.apps(context.app).configVars().info(function (err, config) {
-      if (err) { throw err; }
+    let config = yield heroku.apps(context.app).configVars().info();
 
-      for (var attrname in config) { process.env[attrname] = config[attrname]; }
+    for (var attrname in config) { process.env[attrname] = config[attrname]; }
 
-      // launch the command
-      var command = spawn(context.args[0], context.args.slice(1), { env: process.env, cwd: context.cwd });
-      command.stdout.on('data', function(data) {
-        process.stdout.write(data);
-      });
-      command.stderr.on('data', function(data) {
-        process.stderr.write(data);
-      });
-      command.on('error', function(err) {
-        process.stderr.write(String(err) + '\n');
-        process.exitCode = 99;
-      });
-      command.on('exit', function(err) {
-        process.exitCode = err;
-      });
+    // launch the command
+    var command = spawn(context.args[0], context.args.slice(1), { env: process.env, cwd: context.cwd });
+    command.stdout.on('data', function(data) {
+      process.stdout.write(data);
+    });
+    command.stderr.on('data', function(data) {
+      process.stderr.write(data);
+    });
+    command.on('error', function(err) {
+      process.stderr.write(String(err) + '\n');
+      process.exitCode = 99;
+    });
+    command.on('exit', function(err) {
+      process.exitCode = err;
     });
   }))
 };

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "test": "jshint ."
   },
   "dependencies": {
+    "co": "4.6.0",
+    "heroku-cli-util": "^5.4.6",
     "heroku-client": "^1.9.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This wraps the command in `cli.command` and uses the provided `heroku` API interface, which automatically prompts for 2fa codes on paranoid apps.
